### PR TITLE
Fix/dont mark and show interruption UI when is granted

### DIFF
--- a/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
+++ b/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
@@ -39,7 +39,7 @@ public struct RewardAd: View {
                         YouTubeView(isEnded: .constant(false), videoUrl: adVm.videoUrl ?? "")
                             .environmentObject(adVm)
                     } else {
-                        VideoView(isEnded: .constant(false), videoUrl: adVm.videoUrl ?? "")
+                        VideoView(isEnded: .constant(false), videoUrl: adVm.videoUrl ?? "", isGranted: adVm.currentAd?.is_granted ?? false)
                             .environmentObject(adVm)
                     }
                 })
@@ -113,7 +113,7 @@ public struct RewardAd: View {
                         YouTubeView(isEnded: .constant(false), videoUrl: adVm.videoUrl ?? "")
                             .environmentObject(adVm)
                     } else {
-                        VideoView(isEnded: .constant(false), videoUrl: adVm.videoUrl ?? "")
+                        VideoView(isEnded: .constant(false), videoUrl: adVm.videoUrl ?? "", isGranted: adVm.currentAd?.is_granted ?? false)
                             .environmentObject(adVm)
                     }
                 })

--- a/Sources/CaRetailBoosterSDK/Components/VideoView.swift
+++ b/Sources/CaRetailBoosterSDK/Components/VideoView.swift
@@ -28,12 +28,14 @@ public struct VideoView: View {
     @State var timeText: String = ""
     var videoDuration: Double = 0
     @State var isMuted: Bool = true
+    var isGranted: Bool = false
     
-    init(isEnded: Binding<Bool>, videoUrl: String) {
+    init(isEnded: Binding<Bool>, videoUrl: String, isGranted: Bool) {
         player = AVPlayer(url: URL(string: videoUrl)!)
         _isEnded = isEnded
         // ミュート状態で再生を開始
         player.isMuted = true
+        self.isGranted = isGranted
         
         // トータルの再生時間取得
         // TODO 計算に時間がかかってUIをブロッキングするのでadのdurationを使う
@@ -71,7 +73,8 @@ public struct VideoView: View {
                     rewardAdVm.isVideoPlaying = false
                     
                     // 途中で再生を停止した場合、リワードを獲得できない旨をユーザーに通知する
-                    rewardAdVm.isVideoInterrupted = true
+                    // 獲得済みの場合は通知しない
+                    rewardAdVm.isVideoInterrupted = self.isGranted ? false : true
                 }, label: {
                     Image(systemName: "xmark")
                         .resizable()
@@ -98,7 +101,8 @@ public struct VideoView: View {
                     // モーダルを閉じる
                     isEnded = true
                     rewardAdVm.isVideoPlaying = false
-                    rewardAdVm.isRewardCoverOpened = true
+                    // 獲得済みの場合、リワード獲得UIは表示しない
+                    rewardAdVm.isRewardCoverOpened = self.isGranted ? false : true
                 })
                 .onAppear {
                     player.play()
@@ -193,7 +197,8 @@ public struct VideoView: View {
     
     VideoView(
         isEnded: .constant(false),
-        videoUrl: "https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_1mb.mp4"
+        videoUrl: "https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_1mb.mp4",
+        isGranted: false
     )
     .onAppear {
         vm.currentAd = Reward(index: 1, tag_id: "tag-id1", format_type: AdFormatType.VIDEO.rawValue, video_type: VideoType.STANDARD.rawValue, is_granted: true, webview_url: AdWebViewUrl(contents: "http://localhost:3000/reward.html", getting: "http://localhost:3000/survey.html", interruption: "http://localhost:3000/message/interrupt"), imp_url: "http://localhost:3000/api/imp/imp", view_url: "http://localhost:3000/api/view/view", param: "param1")

--- a/Sources/CaRetailBoosterSDK/Components/VideoView.swift
+++ b/Sources/CaRetailBoosterSDK/Components/VideoView.swift
@@ -74,7 +74,7 @@ public struct VideoView: View {
                     
                     // 途中で再生を停止した場合、リワードを獲得できない旨をユーザーに通知する
                     // 獲得済みの場合は通知しない
-                    rewardAdVm.isVideoInterrupted = self.isGranted ? false : true
+                    rewardAdVm.isVideoInterrupted = !self.isGranted
                 }, label: {
                     Image(systemName: "xmark")
                         .resizable()
@@ -102,7 +102,7 @@ public struct VideoView: View {
                     isEnded = true
                     rewardAdVm.isVideoPlaying = false
                     // 獲得済みの場合、リワード獲得UIは表示しない
-                    rewardAdVm.isRewardCoverOpened = self.isGranted ? false : true
+                    rewardAdVm.isRewardCoverOpened = !self.isGranted
                 })
                 .onAppear {
                     player.play()


### PR DESCRIPTION
# タスク
- https://linear.app/retailads/issue/REB-482/standard動画アンケートの場合獲得済みならmarkしないように修正
- https://linear.app/retailads/issue/REB-481/standard動画の場合獲得済みなら中断モーダルが出ないように修正

## やったこと
- [x] 獲得済みの場合、中断や獲得UI（mark）を表示しないように修正

## 動作確認
- Video
  - Standard



https://github.com/user-attachments/assets/b0e3b36f-771a-446b-adec-113ccce5e46b


  
  - YouTube
 

https://github.com/user-attachments/assets/e614628f-b781-4bc1-a845-1fa858729712





- VideoSurvey



https://github.com/user-attachments/assets/6edd8ffe-a361-4a84-8f27-aacb24942816



## 確認してほしいこと
- 実装および動作問題ないか？

## マージ後のフロー

## その他
- Surveyはそもそも表示しないように修正する
  - 関連スレッド: https://caadtech.slack.com/archives/C073X8TM690/p1741924931320229
