### PR TITLE
Fix/cocoapods preview assets

### DIFF
--- a/CaRetailBoosterSDK.podspec
+++ b/CaRetailBoosterSDK.podspec
@@ -9,5 +9,7 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.0'
-  s.source_files = 'Sources/CaRetailBoosterSDK/**/*'
+  s.source_files = 'Sources/CaRetailBoosterSDK/**/*.swift'
+  s.exclude_files = 'Sources/CaRetailBoosterSDK/Preview Content/**/*'
+  s.resources = ['Sources/CaRetailBoosterSDK/PrivacyInfo.xcprivacy']
 end 

--- a/CaRetailBoosterSDK.podspec
+++ b/CaRetailBoosterSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CaRetailBoosterSDK'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'Retail Booster SDK'
   s.homepage         = 'https://github.com/CyberAgentAI/caretailbooster-sdk-ios'
   s.license          = { :type => 'Proprietary', :file => 'LICENSE', :text => 'All rights reserved.' }


### PR DESCRIPTION
## 対応内容
- CocoaPodsのインストールで失敗する問題を修正
 - `[!] Unable to find other source ref for Contents.json for target CaRetailBoosterSDK.`
 - プレビューアセットを削除した
- SDKのバージョンを`1.3.1`にアップデートしました