### PR TITLE
Refactor full screen modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,14 +56,16 @@ make list-booted  # 起動中のシミュレータ一覧
 - **BannerAd**: 固定サイズのバナー広告
 - **RewardAd**: リワード付きインタラクティブ広告（動画/アンケート）- フルスクリーンモーダル制御
 - **SwiftUIWebView**: Web コンテンツ用の WebKit ラッパー（JavaScript-Swift 間通信）
+- **RewardModalModifier**: iOS 15以上/以下に対応したモーダル表示の統一実装
 
 ### データフロー
 
 1. AdViewModel が AdCall サービスから広告をリクエスト
 2. AdCall が設定された環境エンドポイントから取得
 3. 広告がキャッシュされ、UI コンポーネント経由で表示
-4. AdTracking がインプレッションとインタラクションを記録
-5. コールバックがイベント（リワード、クリック）をホストアプリに通知
+4. JavaScriptメッセージに応じてModalType（video/videoSurvey/survey）でモーダル表示
+5. AdTracking がインプレッションとインタラクションを記録
+6. コールバックがイベント（リワード、クリック）をホストアプリに通知
 
 ## 環境設定
 
@@ -164,7 +166,7 @@ TagGroup モデルを通じて、カスタマイズ可能なタイトルと説�
 Sources/CaRetailBoosterSDK/
 ├── Components/      # UI コンポーネント（BannerAd、RewardAd、SwiftUIWebView）
 ├── Const/           # 定数定義（サーバーURL等）
-├── Models/          # データモデルと設定型（Callback、Options、RunMode）
+├── Models/          # データモデルと設定型（ModalType、Callback、Options、RunMode）
 ├── Services/        # ビジネスロジック（AdCall、AdTracking、Notification）
 ├── Utils/           # ユーティリティ（DeviceInfo）
 ├── View Models/     # MVVM ビューモデル（AdViewModel、BaseWebViewVM）

--- a/Sources/CaRetailBoosterSDK/Components/BannerAd.swift
+++ b/Sources/CaRetailBoosterSDK/Components/BannerAd.swift
@@ -16,10 +16,9 @@ struct BannerAd: View {
     }
     
     public var body: some View {
-        let vm = BaseWebViewVM()
+        let vm = BaseWebViewVM(bannerAd: ad)
         SwiftUIWebView(viewModel: vm)
             .onAppear(perform: {
-                vm.bannerAd = ad
                 vm.enableImpTracking(adType: .BANNER)
                 vm.loadWebPage(webResource: ad.webview_url)
             })

--- a/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
+++ b/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
@@ -18,109 +18,77 @@ struct RewardAd: View {
     
     public var body: some View {
         let vm = BaseWebViewVM(ad: ad, rewardVm: adVm)
-        if #available(iOS 15.0, *) {
-            SwiftUIWebView(viewModel: vm)
-                .onAppear(perform: {
-                    if !adVm.hasImpressionBeenSent(for: ad.ad_id) {
-                        vm.enableImpTracking(adType: .REWARD)
-                        adVm.markImpressionSent(for: ad.ad_id)
-                    }
-                    vm.loadWebPage(webResource: ad.webview_url.contents)
-                })
-                .frame(width: adVm.options?.rewardAd?.width ?? 173, height: adVm.options?.rewardAd?.height ?? 210)
-                .onReceive(NotificationCenter.default.publisher(for: NSNotification.Alert))
-            { data in
-                print("Alert notification received")
-                // TODO: エラー通知
-                showErrorAlert = true
-            }
-            .onDisappear(perform: {
-                vm.stopTracking()
-            })
-            .fullScreenCover(
-                isPresented: $adVm.isVideoPlaying,
-                content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
-                    VStack {
-                        SwiftUIWebView(viewModel: videoSurveyVm)
-                            .onAppear() {
-                                videoSurveyVm.loadWebPage(webResource: adVm.videoUrl ?? "")
-                            }
-                    }.background(.black.opacity(0.5))
-                })
-            .fullScreenCover(
-                isPresented: $adVm.isVideoSurveyPlaying,
-                content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
-                    VStack {
-                        SwiftUIWebView(viewModel: videoSurveyVm)
-                            .onAppear() {
-                                videoSurveyVm.loadWebPage(webResource: adVm.videoSurveyUrl ?? "")
-                            }
-                    }.background(.black.opacity(0.5))
-                })
-            .fullScreenCover(isPresented: $adVm.isSurveyPanelShowed, content: {
-                let surveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
-                VStack {
-                    SwiftUIWebView(viewModel: surveyVm)
-                        .onAppear() {
-                            surveyVm.loadWebPage(webResource: adVm.surveyUrl ?? "")
-                        }
-                }.background(.black.opacity(0.5))
-            })
-        } else {
-            // Fallback on earlier versions
-            SwiftUIWebView(viewModel: vm)
-                .onAppear(perform: {
-                    if !adVm.hasImpressionBeenSent(for: ad.ad_id) {
-                        vm.enableImpTracking(adType: .REWARD)
-                        adVm.markImpressionSent(for: ad.ad_id)
-                    }
-                    vm.loadWebPage(webResource: ad.webview_url.contents)
-                })
-                .frame(width: adVm.options?.rewardAd?.width ?? 173, height: adVm.options?.rewardAd?.height ?? 210)
-                .onReceive(NotificationCenter.default.publisher(for: NSNotification.Alert))
-            { data in
-                print("Alert notification received")
-                // TODO: エラー通知
-                showErrorAlert = true
-            }
-            .onDisappear(perform: {
-                vm.stopTracking()
-            })
-            .fullScreenModal(
-                isPresented: $adVm.isVideoPlaying,
-                content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
-                    VStack {
-                        SwiftUIWebView(viewModel: videoSurveyVm)
-                            .onAppear() {
-                                videoSurveyVm.loadWebPage(webResource: adVm.videoUrl ?? "")
-                            }
-                    }.background(Color.black.opacity(0.5))
-                })
-            .fullScreenModal(
-                isPresented: $adVm.isVideoSurveyPlaying,
-                content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
-                    VStack {
-                        SwiftUIWebView(viewModel: videoSurveyVm)
-                            .onAppear() {
-                                videoSurveyVm.loadWebPage(webResource: adVm.videoSurveyUrl ?? "")
-                            }
-                }.background(Color.black.opacity(0.5))
-            })
-            .fullScreenModal(isPresented: $adVm.isSurveyPanelShowed, content: {
-                let surveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
-                VStack {
-                    SwiftUIWebView(viewModel: surveyVm)
-                        .onAppear() {
-                            surveyVm.loadWebPage(webResource: adVm.surveyUrl ?? "")
-                        }
+        SwiftUIWebView(viewModel: vm)
+            .onAppear(perform: {
+                if !adVm.hasImpressionBeenSent(for: ad.ad_id) {
+                    vm.enableImpTracking(adType: .REWARD)
+                    adVm.markImpressionSent(for: ad.ad_id)
                 }
-                .background(Color.black.opacity(0.5))
+                vm.loadWebPage(webResource: ad.webview_url.contents)
             })
+            .frame(width: adVm.options?.rewardAd?.width ?? 173, height: adVm.options?.rewardAd?.height ?? 210)
+            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Alert)) { data in
+                print("Alert notification received")
+                // TODO: エラー通知
+                showErrorAlert = true
+            }
+            .onDisappear(perform: {
+                vm.stopTracking()
+            })
+            .modifier(RewardModalModifier(adVm: adVm))
+    }
+}
 
+@available(iOS 13.0, *)
+private struct RewardModalModifier: ViewModifier {
+    @ObservedObject var adVm: AdViewModel
+    
+    private var isModalPresented: Binding<Bool> {
+        Binding(
+            get: { adVm.activeModal.isPresented },
+            set: { newValue in
+                if !newValue {
+                    adVm.closeModal()
+                }
+            }
+        )
+    }
+
+    func body(content: Content) -> some View {
+        if #available(iOS 15.0, *) {
+            content
+                .fullScreenCover(
+                    isPresented: isModalPresented,
+                    content: {
+                        if let url = adVm.activeModal.url {
+                            let modalVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
+                            VStack {
+                                SwiftUIWebView(viewModel: modalVm)
+                                    .onAppear {
+                                        modalVm.loadWebPage(webResource: url)
+                                    }
+                            }
+                            .background(.black.opacity(0.5))
+                        }
+                    }
+                )
+        } else {
+            content
+                .fullScreenModal(
+                    isPresented: isModalPresented,
+                    content: {
+                        if let url = adVm.activeModal.url {
+                            let modalVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
+                            VStack {
+                                SwiftUIWebView(viewModel: modalVm)
+                                    .onAppear {
+                                        modalVm.loadWebPage(webResource: url)
+                                    }
+                            }
+                            .background(Color.black.opacity(0.5))
+                        }
+                    }
+                )
         }
     }
 }

--- a/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
+++ b/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
@@ -17,12 +17,10 @@ struct RewardAd: View {
     }
     
     public var body: some View {
-        let vm = BaseWebViewVM()
+        let vm = BaseWebViewVM(ad: ad, rewardVm: adVm)
         if #available(iOS 15.0, *) {
             SwiftUIWebView(viewModel: vm)
                 .onAppear(perform: {
-                    vm.ad = ad
-                    vm.rewardVm = adVm
                     if !adVm.hasImpressionBeenSent(for: ad.ad_id) {
                         vm.enableImpTracking(adType: .REWARD)
                         adVm.markImpressionSent(for: ad.ad_id)
@@ -42,11 +40,10 @@ struct RewardAd: View {
             .fullScreenCover(
                 isPresented: $adVm.isVideoPlaying,
                 content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd)
+                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
                     VStack {
                         SwiftUIWebView(viewModel: videoSurveyVm)
                             .onAppear() {
-                                videoSurveyVm.rewardVm = adVm
                                 videoSurveyVm.loadWebPage(webResource: adVm.videoUrl ?? "")
                             }
                     }.background(.black.opacity(0.5))
@@ -54,21 +51,19 @@ struct RewardAd: View {
             .fullScreenCover(
                 isPresented: $adVm.isVideoSurveyPlaying,
                 content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd)
+                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
                     VStack {
                         SwiftUIWebView(viewModel: videoSurveyVm)
                             .onAppear() {
-                                videoSurveyVm.rewardVm = adVm
                                 videoSurveyVm.loadWebPage(webResource: adVm.videoSurveyUrl ?? "")
                             }
                     }.background(.black.opacity(0.5))
                 })
             .fullScreenCover(isPresented: $adVm.isSurveyPanelShowed, content: {
-                let surveyVm = BaseWebViewVM(ad: adVm.currentAd)
+                let surveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
                 VStack {
                     SwiftUIWebView(viewModel: surveyVm)
                         .onAppear() {
-                            surveyVm.rewardVm = adVm
                             surveyVm.loadWebPage(webResource: adVm.surveyUrl ?? "")
                         }
                 }.background(.black.opacity(0.5))
@@ -77,8 +72,6 @@ struct RewardAd: View {
             // Fallback on earlier versions
             SwiftUIWebView(viewModel: vm)
                 .onAppear(perform: {
-                    vm.ad = ad
-                    vm.rewardVm = adVm
                     if !adVm.hasImpressionBeenSent(for: ad.ad_id) {
                         vm.enableImpTracking(adType: .REWARD)
                         adVm.markImpressionSent(for: ad.ad_id)
@@ -98,11 +91,10 @@ struct RewardAd: View {
             .fullScreenModal(
                 isPresented: $adVm.isVideoPlaying,
                 content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd)
+                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
                     VStack {
                         SwiftUIWebView(viewModel: videoSurveyVm)
                             .onAppear() {
-                                videoSurveyVm.rewardVm = adVm
                                 videoSurveyVm.loadWebPage(webResource: adVm.videoUrl ?? "")
                             }
                     }.background(Color.black.opacity(0.5))
@@ -110,21 +102,19 @@ struct RewardAd: View {
             .fullScreenModal(
                 isPresented: $adVm.isVideoSurveyPlaying,
                 content: {
-                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd)
+                    let videoSurveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
                     VStack {
                         SwiftUIWebView(viewModel: videoSurveyVm)
                             .onAppear() {
-                                videoSurveyVm.rewardVm = adVm
                                 videoSurveyVm.loadWebPage(webResource: adVm.videoSurveyUrl ?? "")
                             }
                 }.background(Color.black.opacity(0.5))
             })
             .fullScreenModal(isPresented: $adVm.isSurveyPanelShowed, content: {
-                let surveyVm = BaseWebViewVM(ad: adVm.currentAd)
+                let surveyVm = BaseWebViewVM(ad: adVm.currentAd, rewardVm: adVm)
                 VStack {
                     SwiftUIWebView(viewModel: surveyVm)
                         .onAppear() {
-                            surveyVm.rewardVm = adVm
                             surveyVm.loadWebPage(webResource: adVm.surveyUrl ?? "")
                         }
                 }

--- a/Sources/CaRetailBoosterSDK/Models/ModalType.swift
+++ b/Sources/CaRetailBoosterSDK/Models/ModalType.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@available(iOS 13.0, *)
+enum ModalType: Equatable {
+    case video(url: String)
+    case videoSurvey(url: String)
+    case survey(url: String)
+    case none
+    
+    var url: String? {
+        switch self {
+        case .video(let url), .videoSurvey(let url), .survey(let url):
+            return url
+        case .none:
+            return nil
+        }
+    }
+    
+    var isPresented: Bool {
+        self != .none
+    }
+}

--- a/Sources/CaRetailBoosterSDK/View Models/AdViewModel.swift
+++ b/Sources/CaRetailBoosterSDK/View Models/AdViewModel.swift
@@ -15,15 +15,8 @@ class AdViewModel: ObservableObject {
     @Published public var areaName: String?
     @Published public var areaDescription: String?
 
-    @Published var isVideoPlaying: Bool = false
-    @Published var isSurveyPanelShowed: Bool = false
-    @Published var isVideoSurveyPlaying: Bool = false
-    
+    @Published var activeModal: ModalType = .none
     @Published var currentAd: Reward?
-    @Published var videoUrl: String?
-    @Published var surveyUrl: String?
-    @Published var videoSurveyUrl: String?
-    
     @Published public var callback: Callback?
     @Published public var options: Options?
     
@@ -116,5 +109,15 @@ class AdViewModel: ObservableObject {
 
     public func resetImpressionSentAdIds() {
         sentImpAdIds.removeAll()
+    }
+
+    func showModal(type: ModalType, ad: Reward) {
+        currentAd = ad
+        activeModal = type
+    }
+
+    func closeModal() {
+        activeModal = .none
+        currentAd = nil
     }
 }

--- a/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
+++ b/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
@@ -13,35 +13,45 @@ enum MessageHandler: String, CaseIterable {
 @MainActor
 @available(iOS 13.0, *)
 class BaseWebViewVM: ObservableObject {
-    var webView: WKWebView
-    var rewardVm: AdViewModel?
-    var ad: Reward?
-    var bannerAd: Banner?
-    
-    // Tracking用のパラメータ
-    var enableTracking: Bool = false
-    var trackingEndpoint: String?
-    var trackingParam: String?
-    
-    init(rewardVm: AdViewModel? = nil, ad: Reward? = nil) {
+    lazy var webView: WKWebView = {
         let config = WKWebViewConfiguration()
         config.allowsInlineMediaPlayback = true
         // this will not require any gesture for triggering playback
         config.mediaTypesRequiringUserActionForPlayback = []
-        
-        self.webView = WKWebView(frame: .zero,
-                                 configuration: config)
-        
+
+        let webView = WKWebView(
+            frame: .zero,
+            configuration: config)
+
         if #available(iOS 16.4, *) {
 #if DEBUG
-            self.webView.isInspectable = true
+            webView.isInspectable = true
 #endif
         } else {
             // Fallback on earlier versions
         }
-        
-        self.rewardVm = rewardVm
+
+        return webView
+    }()
+
+    var rewardVm: AdViewModel?
+    var ad: Reward?
+    var bannerAd: Banner?
+
+    // Tracking用のパラメータ
+    var enableTracking: Bool = false
+    var trackingEndpoint: String?
+    var trackingParam: String?
+
+    // init for banner
+    init(bannerAd: Banner) {
+        self.bannerAd = bannerAd
+    }
+
+    // init for reward
+    init(ad: Reward? = nil, rewardVm: AdViewModel) {
         self.ad = ad
+        self.rewardVm = rewardVm
     }
     
     func loadWebPage(webResource: String) {

--- a/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
+++ b/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
@@ -68,31 +68,19 @@ class BaseWebViewVM: ObservableObject {
     func messageFrom(fromHandler: MessageHandler, message: String) {
         switch fromHandler {
         case .playVideo:
-            if ad != nil {
-                rewardVm?.currentAd = ad
-                rewardVm?.videoUrl = message
-                rewardVm?.isVideoPlaying = true
+            if let ad {
+                rewardVm?.showModal(type: .video(url: message), ad: ad)
             }
         case .playVideoSurvey:
-            if ad != nil {
-                rewardVm?.currentAd = ad
-                rewardVm?.videoSurveyUrl = message
-                rewardVm?.isVideoSurveyPlaying = true
+            if let ad {
+                rewardVm?.showModal(type: .videoSurvey(url: message), ad: ad)
             }
         case .showModal:
-            if ad != nil {
-                rewardVm?.currentAd = ad
-                rewardVm?.surveyUrl = message
-                rewardVm?.isSurveyPanelShowed = true
+            if let ad {
+                rewardVm?.showModal(type: .survey(url: message), ad: ad)
             }
         case .closeModal:
-            if ad != nil {
-                rewardVm?.currentAd = nil
-                rewardVm?.isSurveyPanelShowed = false // リワード獲得済みなのでサーベイモーダルを閉じる
-            }
-            
-            rewardVm?.isVideoPlaying = false
-            rewardVm?.isVideoSurveyPlaying = false
+            rewardVm?.closeModal()
         case .onMarkSuccess:
             // マーク完了をSDKユーザーに通知
             rewardVm?.callback?.onMarkSucceeded()

--- a/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
+++ b/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
@@ -13,32 +13,17 @@ enum MessageHandler: String, CaseIterable {
 @MainActor
 @available(iOS 13.0, *)
 class BaseWebViewVM: ObservableObject {
-    @Published var webResource: String?
     var webView: WKWebView
-    
-    // MARK: - Properties for Javascript alert, confirm, and prompt dialog boxes
-    
-    @Published var showPanel: Bool = false
-    @Published var isSurveyPanelShowed: Bool = false
-    
-    var rewardAds: RewardAds?
     var rewardVm: AdViewModel?
-    
-    var onVideoStart: (() -> Void)?
-    
     var ad: Reward?
     var bannerAd: Banner?
-    
-    var youtubeVideoId: String?
     
     // Tracking用のパラメータ
     var enableTracking: Bool = false
     var trackingEndpoint: String?
     var trackingParam: String?
     
-    init(webResource: String? = nil, rewardVm: AdViewModel? = nil, onVideoStart: (() -> Void)? = nil, ad: Reward? = nil, youtubeVideoId: String? = nil) {
-        self.webResource = webResource
-        
+    init(rewardVm: AdViewModel? = nil, ad: Reward? = nil) {
         let config = WKWebViewConfiguration()
         config.allowsInlineMediaPlayback = true
         // this will not require any gesture for triggering playback
@@ -55,29 +40,17 @@ class BaseWebViewVM: ObservableObject {
             // Fallback on earlier versions
         }
         
-        if let rewardVm = rewardVm {
-            self.rewardVm = rewardVm
-        }
-        
-        self.onVideoStart = onVideoStart
-        
+        self.rewardVm = rewardVm
         self.ad = ad
-        
-        if let youtubeVideoId = youtubeVideoId {
-            self.youtubeVideoId = youtubeVideoId
-        }
     }
     
     func loadWebPage(webResource: String) {
-        //        if let webResource = webResource {
         guard let url = URL(string: webResource) else {
             print("Bad URL")
             return
         }
-        
         let request = URLRequest(url: url)
         webView.load(request)
-        //        }
     }
     
     // MARK: - Functions for messaging
@@ -97,8 +70,6 @@ class BaseWebViewVM: ObservableObject {
                 rewardVm?.isVideoSurveyPlaying = true
             }
         case .showModal:
-            self.isSurveyPanelShowed = true
-            
             if ad != nil {
                 rewardVm?.currentAd = ad
                 rewardVm?.surveyUrl = message
@@ -127,16 +98,6 @@ class BaseWebViewVM: ObservableObject {
             }
             // notificationを使用して、Flutter側にfetchAdsを通知する
             NotificationCenter.default.post(name: NSNotification.FetchAds, object: nil)
-        }
-    }
-    
-    func messageTo(message: String) {
-        let escapedMessage = message.replacingOccurrences(of: "\"", with: "\\\"")
-        let js = "window.postMessage(\"\(escapedMessage)\", \"*\")"
-        self.webView.evaluateJavaScript(js) { (result, error) in
-            if let error = error {
-                print("Error: \(error.localizedDescription)")
-            }
         }
     }
     


### PR DESCRIPTION
## 対応内容
- `BaseWebViewVM` で使われていない不要なプロパティを削除
  - この時点で問題なくビルドを通ること確認
- `BaseWebViewVM` のinit周りをリファクタ
-  フルスクリーンモーダルの開閉ロジックを簡素化
   - `AdViewModel` にあった3つの変数と3つのURLを `ModalType` に統合して、
  iOS 15以上/以下の重複しているコードを削除しリファクタしました。