### PR TITLE
fix: add webview load once and view model cache

### DIFF
--- a/CaRetailBoosterSDK.podspec
+++ b/CaRetailBoosterSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CaRetailBoosterSDK'
-  s.version          = '1.6.4-dev.0'
+  s.version          = '1.6.4-dev.2'
   s.summary          = 'Retail Booster SDK'
   s.homepage         = 'https://github.com/CyberAgentAI/caretailbooster-sdk-ios'
   s.license          = { :type => 'Proprietary', :file => 'LICENSE', :text => 'All rights reserved.' }

--- a/CaRetailBoosterSDK.podspec
+++ b/CaRetailBoosterSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CaRetailBoosterSDK'
-  s.version          = '1.6.3'
+  s.version          = '1.6.4-dev.0'
   s.summary          = 'Retail Booster SDK'
   s.homepage         = 'https://github.com/CyberAgentAI/caretailbooster-sdk-ios'
   s.license          = { :type => 'Proprietary', :file => 'LICENSE', :text => 'All rights reserved.' }

--- a/CaRetailBoosterSDK.podspec
+++ b/CaRetailBoosterSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CaRetailBoosterSDK'
-  s.version          = '1.6.4-dev.2'
+  s.version          = '1.6.4'
   s.summary          = 'Retail Booster SDK'
   s.homepage         = 'https://github.com/CyberAgentAI/caretailbooster-sdk-ios'
   s.license          = { :type => 'Proprietary', :file => 'LICENSE', :text => 'All rights reserved.' }

--- a/Sources/CaRetailBoosterSDK/Components/BannerAd.swift
+++ b/Sources/CaRetailBoosterSDK/Components/BannerAd.swift
@@ -17,11 +17,12 @@ struct BannerAd: View {
     }
     
     public var body: some View {
-        let vm = BaseWebViewVM(bannerAd: ad)
+        let vm = adVm.getOrCreateBannerVM(for: ad)
         SwiftUIWebView(viewModel: vm)
             .onAppear(perform: {
                 vm.enableImpTracking(adType: .BANNER)
-                vm.loadWebPage(webResource: ad.webview_url)
+                // 既に事前ロード済みの場合はスキップされる
+                vm.loadWebPageOnce(webResource: ad.webview_url)
             })
             .frame(
                 width: adVm.options?.size?.width ?? CGFloat(ad.width),

--- a/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
+++ b/Sources/CaRetailBoosterSDK/Components/RewardAd.swift
@@ -17,14 +17,15 @@ struct RewardAd: View {
     }
     
     public var body: some View {
-        let vm = BaseWebViewVM(ad: ad, rewardVm: adVm)
+        let vm = adVm.getOrCreateRewardVM(for: ad)
         SwiftUIWebView(viewModel: vm)
             .onAppear(perform: {
                 if !adVm.hasImpressionBeenSent(for: ad.ad_id) {
                     vm.enableImpTracking(adType: .REWARD)
                     adVm.markImpressionSent(for: ad.ad_id)
                 }
-                vm.loadWebPage(webResource: ad.webview_url.contents)
+                // 既に事前ロード済みの場合はスキップされる
+                vm.loadWebPageOnce(webResource: ad.webview_url.contents)
             })
             .frame(width: adVm.options?.size?.width ?? 173, height: adVm.options?.size?.height ?? 210)
             .onReceive(NotificationCenter.default.publisher(for: NSNotification.Alert)) { data in

--- a/Sources/CaRetailBoosterSDK/View Models/AdViewModel.swift
+++ b/Sources/CaRetailBoosterSDK/View Models/AdViewModel.swift
@@ -26,6 +26,8 @@ class AdViewModel: ObservableObject {
     private var lastFetchedRewardAds: [Reward] = []
     // impリクエストの送信状態を管理
     private var sentImpAdIds: Set<Int> = []
+    // WebView VMキャッシュ（事前ロード用）
+    private var webViewVMCache: [String: BaseWebViewVM] = [:]
     
     let mediaId: String
     let userId: String
@@ -70,6 +72,9 @@ class AdViewModel: ObservableObject {
                 let newAdIds = Set(res.rewardAds.map { $0.ad_id })
                 sentImpAdIds = sentImpAdIds.intersection(newAdIds)
 
+                // VMキャッシュをクリア
+                webViewVMCache.removeAll()
+
                 rewardAds = res.rewardAds
                 bannerAds = res.bannerAds
                 adType = res.adType
@@ -80,6 +85,7 @@ class AdViewModel: ObservableObject {
                 if hasRewardAdsChanged {
                     forceRefreshToken = UUID()
                 }
+                preloadWebViews()
             }
         } catch {
             print("[AdViewModel] Error fetching ads: \(error)")
@@ -122,5 +128,72 @@ class AdViewModel: ObservableObject {
     func closeModal() {
         activeModal = .none
         currentAd = nil
+    }
+    
+    private func preloadWebViews() {
+        guard let adType = adType else {
+            #if DEBUG
+            print("[AdViewModel] No adType set, skipping preload")
+            #endif
+            return
+        }
+        
+        switch adType {
+        case .REWARD:
+            #if DEBUG
+            print("[AdViewModel] Preloading WebViews for \(rewardAds.count) reward ads")
+            #endif
+            for ad in rewardAds {
+                let vm = BaseWebViewVM(ad: ad, rewardVm: self)
+                let key = "reward_\(ad.ad_id)_\(ad.param)"
+                webViewVMCache[key] = vm
+                // 非同期でロード開始
+                vm.loadWebPageOnce(webResource: ad.webview_url.contents)
+            }
+            
+        case .BANNER:
+            #if DEBUG
+            print("[AdViewModel] Preloading WebViews for \(bannerAds.count) banner ads")
+            #endif
+            for ad in bannerAds {
+                let vm = BaseWebViewVM(bannerAd: ad)
+                let key = "banner_\(ad.ad_id)_\(ad.param)"
+                webViewVMCache[key] = vm
+                // 非同期でロード開始
+                vm.loadWebPageOnce(webResource: ad.webview_url)
+            }
+        }
+    }
+    
+    func getOrCreateRewardVM(for ad: Reward) -> BaseWebViewVM {
+        let key = "reward_\(ad.ad_id)_\(ad.param)"
+        if let cached = webViewVMCache[key] {
+            #if DEBUG
+            print("[AdViewModel] Using cached VM for reward ad \(ad.ad_id)")
+            #endif
+            return cached
+        }
+        // フォールバック（キャッシュミス時）
+        #if DEBUG
+        print("[AdViewModel] Cache miss, creating new VM for reward ad \(ad.ad_id)")
+        #endif
+        let vm = BaseWebViewVM(ad: ad, rewardVm: self)
+        return vm
+    }
+    
+    func getOrCreateBannerVM(for ad: Banner) -> BaseWebViewVM {
+        let key = "banner_\(ad.ad_id)_\(ad.param)"
+        if let cached = webViewVMCache[key] {
+            #if DEBUG
+            print("[AdViewModel] Using cached VM for banner ad \(ad.ad_id)")
+            #endif
+            return cached
+        }
+        // フォールバック（キャッシュミス時）
+        #if DEBUG
+        print("[AdViewModel] Cache miss, creating new VM for banner ad \(ad.ad_id)")
+        #endif
+        let vm = BaseWebViewVM(bannerAd: ad)
+        return vm
     }
 }

--- a/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
+++ b/Sources/CaRetailBoosterSDK/View Models/BaseWebViewVM.swift
@@ -44,6 +44,9 @@ class BaseWebViewVM: ObservableObject {
     var trackingEndpoint: String?
     var trackingParam: String?
     var trackingAdId: Int?
+    
+    // WebViewロード済みフラグ（onAppear多重実行防止）
+    private var isLoaded: Bool = false
 
     // init for banner
     init(bannerAd: Banner) {
@@ -63,6 +66,17 @@ class BaseWebViewVM: ObservableObject {
         }
         let request = URLRequest(url: url)
         webView.load(request)
+    }
+    
+    func loadWebPageOnce(webResource: String) {
+        guard !isLoaded else {
+            #if DEBUG
+            print("[BaseWebViewVM] WebView already loaded, skipping reload")
+            #endif
+            return
+        }
+        loadWebPage(webResource: webResource)
+        isLoaded = true
     }
     
     // MARK: - Functions for messaging


### PR DESCRIPTION
## やったこと
- webviewのロードをonAppearで行っているが、初回のみロードするようにフラグで制御
- view modelのcacheを作成し、初期化コストを削減
- ad call時にwebviewのpreloadをできるように修正

## 動作確認
- クライアントアプリの挙動改善を確認
- デグレ確認OK（特に計測まわり）